### PR TITLE
HIP-0013: Profile Data and Wallet Addresses in TXT Records

### DIFF
--- a/HIP-0013.md
+++ b/HIP-0013.md
@@ -125,6 +125,7 @@ Handshake TLDs are encouraged to put IDNS TXT records directly onchain for the b
 * EIP-634: Storage of text records in ENS https://eips.ethereum.org/EIPS/eip-634
 * RFC 1464 https://datatracker.ietf.org/doc/html/rfc1464
 * Handshake OIDC Authentication https://learn.namebase.io/development/guides/handshake-login/handshake-based-oidc-authentication-protocol
+* HTools Handshake Login https://github.com/htools-org/handshake-login
 * James Stevens' Wallet IDs in DNS https://github.com/james-stevens/wallet-ids-in-dns 
 * A proposal for cryptocurrency addresses in DNS https://ma.ttias.be/proposal-cryptocurrency-addresses-dns
 * Simplifying Bitcoin Addresses Using DNS https://bitcoinmagazine.com/technical/simplifying-bitcoin-addresses-dns

--- a/HIP-0013.md
+++ b/HIP-0013.md
@@ -46,8 +46,8 @@ IDNS TXT records can contain one or more records in key=value pairs, separated b
 <pre><code><b>IDNS1</b> profile:avatar=<ins>http://pic.com/me.png</ins> service:com.twitter=<ins>aoxborrow</ins>
 </code></pre>
 
-Records that contain spaces must be single quoted. Single quotes in the record can be escaped with a backslash:
-<pre><code><b>IDNS1</b> profile:location=<ins>'Berkeley, CA'</ins> profile:bio=<ins>'I\'m a passionate advocate for domain innovation.'</ins></code></pre>
+Records that contain spaces must be quoted. Quotes in the record data can be escaped with a backslash:
+<pre><code><b>IDNS1</b> profile:location=<ins>"Berkeley, CA"</ins> profile:bio=<ins>'I\'m a passionate advocate for domain innovation.'</ins></code></pre>
 
 ### Profile Records (`profile`)
 Human-readable user profile text data. 
@@ -58,7 +58,7 @@ Human-readable user profile text data.
 <i>Examples:</i>
 IDNS1 profile:name=aox
 IDNS1 profile:avatar=https://hns.id/domain/aox.hns/avatar.png
-IDNS1 profile:location='Berkeley, CA'
+IDNS1 profile:location="Berkeley, CA"
 IDNS1 profile:email=hey@me.com
 </code></pre>
 
@@ -72,6 +72,7 @@ Service keys must be made up of a reverse dot notation for a namespace which the
 IDNS1 service:com.twitter=aoxborrow
 IDNS1 service:com.github=0xstefan
 IDNS1 service:io.keybase=pinheadmz
+IDNS1 service:.hnschat=skmo
 </code></pre>
 
 ### Wallet Records (`wallet`)
@@ -81,10 +82,10 @@ Cryptocurrency wallet addresses. Uses [SLIP44](https://github.com/satoshilabs/sl
 <pre><code><b>IDNS1 wallet:&lt;cointype&gt;=&lt;address&gt;</b>
 
 <i>Examples:</i>
-IDNS1 wallet:btc=1Dvf5aQkVrVJeasRUDiLATGWLBGFWA9ovY
+IDNS1 wallet:btc=1dvf5aqkvrvjeasrudilatgwlbgfwa9ovy
 IDNS1 wallet:hns=hs1qshuyulxra3pqpwr40303t8pn79232zztuk4qgz
 IDNS1 wallet:5353=hs1qshuyulxra3pqpwr40303t8pn79232zztuk4qgz
-IDNS1 wallet:eth=0xa08abA528da538cd3547a73C93d51B90201294B6
+IDNS1 wallet:eth=0xa08aba528da538cd3547a73c93d51b90201294b6
 </code></pre>
 
 
@@ -108,6 +109,7 @@ Authentication provider for use with "Login with Domain." See [Handshake Login](
 
 <i>Examples:</i>
 IDNS1 auth:id.namebase.io=b9feeee2b4ad5c04dfad360be65ba134aab7d
+IDNS1 auth:id.htools.work=360be65ba134aab7d07ec59f0547a73360be6
 IDNS1 auth:auth.varo.domains=6786769f580809256b4685ef316805265ea1e
 </code></pre>
 
@@ -115,7 +117,7 @@ IDNS1 auth:auth.varo.domains=6786769f580809256b4685ef316805265ea1e
 Applications should respect the `ttl` setting of IDNS TXT records and cache the record data accordingly. Most profile records should have a long TTL, at least one hour (`3600`) or more. For wallet records, in order to replicate the behavior of a [HIP-2 server](https://github.com/pinheadmz/hip2-server), use a short TTL and rotate the wallet addresses frequently. 
 
 ### TLD Records & DNSSEC
-Handshake TLDs are encouraged to put IDNS TXT records directly onchain for the bare TLD. If using delegation (nameservers), DNSSEC is required. DNSSEC is required for all ICANN domains. A resolver may choose to support only `profile` and `service` records for ICANN TLDs that do not support DNSSEC.
+Handshake TLDs are encouraged to put IDNS TXT records directly onchain for the bare TLD. If using delegation (nameservers), DNSSEC is required. DNSSEC is required for all domains. 
 
 
 ## References

--- a/HIP-0013.md
+++ b/HIP-0013.md
@@ -1,0 +1,130 @@
+# HIP-0013: Profile Data and Wallet Addresses in TXT Records
+
+```
+Number:  HIP-0013
+Title:   Profile Data and Wallet Addresses in TXT Records
+Type:    Standards
+Status:  Draft
+Authors: @aoxborrow, @0xStefan, @Falci
+Created: 2024-03-14
+```
+
+## Abstract
+
+This document introduces IDNS (Identity-DNS), a standard for storing portable profile data and crypto wallet addresses securely within DNS TXT records. 
+
+## Motivation
+
+Handshake holds significant potential for decentralized identity and wallet naming, but so far the focus has primarily been on websites. This proposal aims to establish a new and improved standard designed to encourage the development of decentralized identity applications for Handshake.
+
+### Domains as Portable Identities
+By attaching profile data such as a name, avatar, and bio, domains can act as portable online identities. This "bring-your-own-identity" approach, where users control their own data, has been adopted by platforms like [BlueSky](https://atproto.com/specs/handle), [Thunderbolt](https://www.spaceship.com/thunderbolt), and [Farcaster](https://docs.farcaster.xyz/learn/architecture/ens-names), which all utilize domains over traditional usernames.
+
+Domains help overcome the scarcity of desirable namespace on social networks, allowing for more personalized and meaningful identifiers. For example, a proud Texan might choose `@richard.tx` over settling for `@richard_214`. Similarly, verified domains like `@nike.com` establish true authenticity, a clear advantage over fallible methods like blue checkmarks.
+
+### Domains for Wallet Naming
+In the same way that domains provide human-readable names for IP addresses, they can also map human-readable names to lengthy cryptocurrency addresses. Wallet naming makes it easy to send crypto to a friend or donate to a worthy cause. As crypto adoption grows, domains must evolve to support the payment rails of the future. Wallet naming continues to be the primary driver of adoption for blockchain naming systems like [ENS](https://docs.ens.domains/web/resolution).
+
+### Advantages of TXT Records
+Utilizing DNS offers practical benefits over blockchain-based systems: 
+* **Compatible** - Works with both Handshake and ICANN domains across different registrars and DNS providers.
+* **Economical** - No gas fees needed for data storage or ongoing management.
+* **Ease of Use** - Simple for both domain owners and developers. No specialized blockchain knowledge required.
+* **Security** - DNSSEC ensures data integrity, while proven DNS infrastructure guarantees speed & availability.
+
+### DNS: A Strategy for Adoption
+This specification is fully compatible with ICANN domains, which dramatically broadens the potential user base. By growing the identity use-case for DNS domains, we can position Handshake as the superior alternative – private, decentralized, and censor-resistant. By building tools and services around IDNS that support both HNS and DNS domains, we can reach a much wider audience beyond the crypto community.
+
+## TXT Specification
+
+IDNS TXT records begin with **`IDNS1`** (version 1), and use the following format containing a record type, key, and value: 
+
+<pre><code><b>IDNS1 &lt;type&gt;:&lt;key&gt;=&lt;value&gt;</b>
+</code></pre>
+
+IDNS TXT records can contain one or more records in key=value pairs, separated by spaces:
+<pre><code><b>IDNS1</b> profile:avatar=<ins>http://pic.com/me.png</ins> service:com.twitter=<ins>aoxborrow</ins>
+</code></pre>
+
+Records that contain spaces must be single quoted. Single quotes in the record can be escaped with a backslash:
+<pre><code><b>IDNS1</b> profile:location=<ins>'Berkeley, CA'</ins> profile:bio=<ins>'I\'m a passionate advocate for domain innovation.'</ins></code></pre>
+
+### Profile Records (`profile`)
+Human-readable user profile text data. 
+  - **`<key>`** The profile record name, any text key is valid, no spaces.
+  - **`<value>`** The profile record data.
+<pre><code><b>IDNS1 profile:&lt;key&gt;=&lt;value&gt;</b>
+
+<i>Examples:</i>
+IDNS1 profile:name=aox
+IDNS1 profile:avatar=https://hns.id/domain/aox.hns/avatar.png
+IDNS1 profile:location='Berkeley, CA'
+IDNS1 profile:email=hey@me.com
+</code></pre>
+
+### Service Records (`service`)
+Service keys must be made up of a reverse dot notation for a namespace which the service owns, for example, DNS names (e.g. .com, .io) or HNS name (i.e. .hns). Service Keys must contain at least one dot. See [EIP-634](https://eips.ethereum.org/EIPS/eip-634#service-keys).
+  - **`<key>`** A service key associated with the user, e.g. `com.github`.
+  - **`<identifier>`** Identifier for the service, e.g. Github username. 
+<pre><code><b>IDNS1 service:&lt;key&gt;=&lt;identifier&gt;</b>
+
+<i>Examples:</i>
+IDNS1 service:com.twitter=aoxborrow
+IDNS1 service:com.github=0xstefan
+IDNS1 service:io.keybase=pinheadmz
+</code></pre>
+
+### Wallet Records (`wallet`)
+Cryptocurrency wallet addresses. Uses [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) to specify different blockchains.
+  - **`<cointype>`** The type of cryptocurrency, using SLIP44 cointype symbol or number, e.g. `hns` or `5353`
+  - **`<address>`** Wallet address for the specific cryptocurrency.
+<pre><code><b>IDNS1 wallet:&lt;cointype&gt;=&lt;address&gt;</b>
+
+<i>Examples:</i>
+IDNS1 wallet:btc=1Dvf5aQkVrVJeasRUDiLATGWLBGFWA9ovY
+IDNS1 wallet:hns=hs1qshuyulxra3pqpwr40303t8pn79232zztuk4qgz
+IDNS1 wallet:5353=hs1qshuyulxra3pqpwr40303t8pn79232zztuk4qgz
+IDNS1 wallet:eth=0xa08abA528da538cd3547a73C93d51B90201294B6
+</code></pre>
+
+
+### Contenthash Records (`contenthash`)
+A content hash or address for distributed networks like IPFS. See [ENSIP-7](https://docs.ens.domains/ensip/7).
+  - **`<protocol>`** Distributed network protocol name, e.g. `ipfs`.
+  - **`<address>`** Content address or content hash for distributed network.
+<pre><code><b>IDNS1 contenthash:&lt;protocol&gt;=&lt;address&gt;</b>
+
+<i>Examples:</i>
+IDNS1 contenthash:ipfs=c04dfad360be65ba134aab7d07ec59f0547a73ef3168
+IDNS1 contenthash:swarm=d191eb26786769f580809256b4685ef316805265ea1
+</code></pre>
+
+
+### Auth Records (`auth`)
+Authentication provider for use with "Login with Domain." See [Handshake Login](https://learn.namebase.io/development/guides/handshake-login/using-handshake-login#set-up-a-custom-identity-manager). (WIP)
+  - **`<provider>`** Identity provider URL.
+  - **`<fingerprint>`** Provider-specific fingerprint.
+<pre><code><b>IDNS1 auth:&lt;provider&gt;=&lt;fingerprint&gt;</b>
+
+<i>Examples:</i>
+IDNS1 auth:id.namebase.io=b9feeee2b4ad5c04dfad360be65ba134aab7d
+IDNS1 auth:auth.varo.domains=6786769f580809256b4685ef316805265ea1e
+</code></pre>
+
+### TTL & Caching
+Applications should respect the `ttl` setting of IDNS TXT records and cache the record data accordingly. Most profile records should have a long TTL, at least one hour (`3600`) or more. For wallet records, in order to replicate the behavior of a [HIP-2 server](https://github.com/pinheadmz/hip2-server), use a short TTL and rotate the wallet addresses frequently. 
+
+### TLD Records & DNSSEC
+Handshake TLDs are encouraged to put IDNS TXT records directly onchain for the bare TLD. If using delegation (nameservers), DNSSEC is required. DNSSEC is required for all ICANN domains. A resolver may choose to support only `profile` and `service` records for ICANN TLDs that do not support DNSSEC.
+
+
+## References
+* Stefan's Original HIP-0013 - TXT Record Naming Standards https://github.com/handshake-org/HIPs/pull/46
+* EIP-634: Storage of text records in ENS https://eips.ethereum.org/EIPS/eip-634
+* RFC 1464 https://datatracker.ietf.org/doc/html/rfc1464
+* Handshake OIDC Authentication https://learn.namebase.io/development/guides/handshake-login/handshake-based-oidc-authentication-protocol
+* James Stevens' Wallet IDs in DNS https://github.com/james-stevens/wallet-ids-in-dns 
+* A proposal for cryptocurrency addresses in DNS https://ma.ttias.be/proposal-cryptocurrency-addresses-dns
+* Simplifying Bitcoin Addresses Using DNS https://bitcoinmagazine.com/technical/simplifying-bitcoin-addresses-dns
+* OpenAlias https://openalias.org
+* DNSLink https://dnslink.dev

--- a/HIP-0013.md
+++ b/HIP-0013.md
@@ -91,7 +91,7 @@ IDNS1 wallet:eth=0xa08aba528da538cd3547a73c93d51b90201294b6
 
 ### Contenthash Records (`contenthash`)
 A content hash or address for distributed networks like IPFS. See [ENSIP-7](https://docs.ens.domains/ensip/7).
-  - **`<protocol>`** Distributed network protocol name, e.g. `ipfs`.
+  - **`<protocol>`** Distributed network protocol name, e.g. `ipfs`. **NOTE:** this is not used for resolution
   - **`<address>`** Content address or content hash for distributed network.
 <pre><code><b>IDNS1 contenthash:&lt;protocol&gt;=&lt;address&gt;</b>
 


### PR DESCRIPTION
_With permission and input from @0xStefan, this HIP is intended to be the spiritual and literal successor to his original HIP-0013: https://github.com/handshake-org/HIPs/pull/46_

This proposal introduces IDNS (Identity-DNS), a new standard for storing profile data and wallet addresses in DNS TXT records. The `profile` records allow us to build new applications around domains as decentralized identity. The `wallet` records enable simple wallet naming for all Handshake names. The `auth` records are intended to codify the OIDC/OAUTH2 standards first introduced for [Handshake Login](https://learn.namebase.io/development/guides/handshake-login/using-handshake-login).

This is a draft that has been sitting in my brain for a year. Open to any feedback. I will be talking about this at Handycon later today.
